### PR TITLE
fix qconf update

### DIFF
--- a/pandaharvester/commit_timestamp.py
+++ b/pandaharvester/commit_timestamp.py
@@ -1,1 +1,1 @@
-timestamp = "21-09-2019 20:55:27 on contrib_cern (by fahui)"
+timestamp = "04-10-2019 00:08:20 on contrib_cern (by fahui)"

--- a/pandaharvester/commit_timestamp.py
+++ b/pandaharvester/commit_timestamp.py
@@ -1,1 +1,1 @@
-timestamp = "21-09-2019 18:24:59 on contrib_cern (by fahui)"
+timestamp = "21-09-2019 20:55:27 on contrib_cern (by fahui)"

--- a/pandaharvester/harvestercore/db_proxy.py
+++ b/pandaharvester/harvestercore/db_proxy.py
@@ -3032,7 +3032,7 @@ class DBProxy(object):
             return False
 
     # get a cached info
-    def get_cache(self, main_key, sub_key=None):
+    def get_cache(self, main_key, sub_key=None, from_local_cache=True):
         useDB = False
         try:
             # get logger
@@ -3045,7 +3045,7 @@ class DBProxy(object):
             # lock dict
             globalDict.acquire()
             # found
-            if cacheKey in globalDict:
+            if from_local_cache and cacheKey in globalDict:
                 # release dict
                 globalDict.release()
                 # make spec

--- a/pandaharvester/harvestercore/queue_config_mapper.py
+++ b/pandaharvester/harvestercore/queue_config_mapper.py
@@ -1,6 +1,7 @@
 import os
 import json
 import copy
+import time
 import datetime
 import threading
 import importlib
@@ -178,6 +179,7 @@ class QueueConfigMapper(six.with_metaclass(SingletonWithID, object)):
             self.configFromCacher = harvester_config.qconf.configFromCacher
         except AttributeError:
             self.configFromCacher = False
+        self.updateInterval = 600
 
     # load config from DB cache of URL with validation
     def _load_config_from_cache(self):
@@ -242,15 +244,43 @@ class QueueConfigMapper(six.with_metaclass(SingletonWithID, object)):
             resolver = None
         return resolver
 
+    # update last reload time
+    def _update_last_reload_time(self):
+        new_info = '{0:.3f}'.format(time.time())
+        return self.dbProxy.refresh_cache('_qconf_last_reload', '_universal', new_info)
+
+    # get last reload time
+    def _get_last_reload_time(self):
+        cacheSpec = self.dbProxy.get_cache('_qconf_last_reload', '_universal', from_local_cache=False)
+        if cacheSpec is None:
+            return None
+        timestamp = float(cacheSpec.data)
+        return timestamp
+
     # load data
     def load_data(self):
         mainLog = _make_logger(method_name='QueueConfigMapper.load_data')
-        # check interval
-        timeNow = datetime.datetime.utcnow()
-        if self.lastUpdate is not None and timeNow - self.lastUpdate < datetime.timedelta(minutes=10):
-            return
+        with self.lock:
+            # check if to update
+            timeNow_timestamp = time.time()
+            if self.lastUpdate is not None:
+                last_reload_timestamp = self._get_last_reload_time()
+                if (last_reload_timestamp is not None and self.lastUpdate is not None
+                    and datetime.datetime.utcfromtimestamp(last_reload_timestamp) < self.lastUpdate
+                    and timeNow_timestamp - last_reload_timestamp < self.updateInterval):
+                    return
         # start
         with self.lock:
+            # update timesatmp of last reload, lock with check interval
+            got_timesatmp_update_lock = self.dbProxy.get_process_lock('qconf_reload', 'qconf_universal', self.updateInterval)
+            if got_timesatmp_update_lock:
+                retVal = self._update_last_reload_time()
+                if retVal:
+                    mainLog.debug('updated last reload timestamp')
+                else:
+                    mainLog.warning('failed to update last reload timestamp. Skipped')
+            else:
+                mainLog.debug('did not get qconf_reload timestamp lock. Skipped to update last reload timestamp')
             # init
             newQueueConfig = dict()
             localTemplatesDict = dict()

--- a/pandaharvester/harvesterscripts/harvester_admin.py
+++ b/pandaharvester/harvesterscripts/harvester_admin.py
@@ -196,6 +196,7 @@ def qconf_list(arguments):
 def qconf_refresh(arguments):
     from pandaharvester.harvestercore.queue_config_mapper import QueueConfigMapper
     qcm = QueueConfigMapper()
+    qcm._update_last_reload_time()
     qcm.lastUpdate = None
     qcm.load_data()
 


### PR DESCRIPTION
Sync qconf update time for all processes; able to manually trigger qconf update immediately on every thread/process without restarting harvester service