### PR TITLE
protection of non-latin characters in dialogs

### DIFF
--- a/pandaharvester/commit_timestamp.py
+++ b/pandaharvester/commit_timestamp.py
@@ -1,1 +1,1 @@
-timestamp = "04-02-2020 15:40:49 on master (by tmaeno)"
+timestamp = "13-02-2020 15:39:44 on contrib_cern (by fahui)"

--- a/pandaharvester/harvestercore/core_utils.py
+++ b/pandaharvester/harvestercore/core_utils.py
@@ -4,6 +4,7 @@ utilities
 """
 
 import os
+import re
 import sys
 import time
 import zlib
@@ -639,3 +640,9 @@ def pickle_to_text(data):
 # unpickle from text
 def unpickle_from_text(text):
     return pickle.loads(codecs.decode(text.encode(), 'base64'))
+
+
+# remove non-latin characters and return string
+def remove_non_latins(text):
+    ret = re.sub(r'[^\x00-\x7F\x80-\xFF\u0100-\u017F\u0180-\u024F\u1E00-\u1EFF]', '', text)
+    return ret

--- a/pandaharvester/harvestercore/job_spec.py
+++ b/pandaharvester/harvestercore/job_spec.py
@@ -9,6 +9,7 @@ from past.builtins import long
 from future.utils import iteritems
 
 from .spec_base import SpecBase
+from pandaharvester.harvestercore import core_utils
 
 
 class JobSpec(SpecBase):
@@ -501,7 +502,8 @@ class JobSpec(SpecBase):
         if not self.has_attribute('pilotErrorCode'):
             self.set_one_attribute('pilotErrorCode', error_code)
         if not self.has_attribute('pilotErrorDiag'):
-            self.set_one_attribute('pilotErrorDiag', error_dialog)
+            diag = core_utils.remove_non_latins(error_dialog)
+            self.set_one_attribute('pilotErrorDiag', diag)
 
     # not to suppress heartbeat
     def not_suppress_heartbeat(self):

--- a/pandaharvester/harvestercore/work_spec.py
+++ b/pandaharvester/harvestercore/work_spec.py
@@ -11,6 +11,7 @@ from future.utils import iteritems
 from .spec_base import SpecBase
 
 from pandaharvester.harvesterconfig import harvester_config
+from pandaharvester.harvestercore import core_utils
 
 
 # work spec
@@ -380,13 +381,15 @@ class WorkSpec(SpecBase):
     # set dialog message
     def set_dialog_message(self, msg):
         if msg not in (None, ''):
+            msg = core_utils.remove_non_latins(msg)
             msg = msg[:500]
             self.diagMessage = msg
 
     # set pilot error
     def set_pilot_error(self, error_code, error_dialog):
+        diag = core_utils.remove_non_latins(error_dialog)
         self.set_work_attributes({'pilotErrorCode': error_code,
-                                  'pilotErrorDiag': error_dialog})
+                                  'pilotErrorDiag': diag})
 
     # check if has pilot error
     def has_pilot_error(self):
@@ -401,4 +404,4 @@ class WorkSpec(SpecBase):
         if error_code is not None:
             self.errorCode = error_code
         if error_diag not in (None, ''):
-            self.errorDiag = str(error_diag)[:256]
+            self.errorDiag = core_utils.remove_non_latins(str(error_diag))[:256]


### PR DESCRIPTION
To fix that some db_proxy method calls broken with non-latin characters in dialogues:

```
2020-02-13 03:47:27,696 panda.log.db_proxy: DEBUG    update_jobs_workers <workerID=122295655> update worker
2020-02-13 03:47:27,696 panda.log.db_proxy: DEBUG    execute : thr=1010853-140496947226688-11 sql=UPDATE work_table SET status=:status,workParams=:workParams,workAttributes=:workAttributes,modificationTime=:modificationTime,lastUpdate=:lastUpdate,lockedBy=:lockedBy,postProcessed=:postProcessed,nativeStatus=:nativeStatus,diagMessage=:diagMessage,checkTime=:checkTime,errorCode=:errorCode,errorDiag=:errorDiag  WHERE workerID=:workerID AND lockedBy=:cr_lockedBy AND (status NOT IN (:st1,:st2,:st3,:st4))  var={':status': 'idle', ':workParams': '{"lastCheckAt": 1579742638.660122, "finalMonStatus": "cancelled"}', ':workAttributes': '{"batchLog": "https://aipanda156.cern.ch/condor_logs_2/20-01-23_01/grid.2442464.0.log", "stdOut": "https://aipanda156.cern.ch/condor_logs_2/20-01-23_01/grid.2442464.0.out", "stdErr": "https://aipanda156.cern.ch/condor_logs_2/20-01-23_01/grid.2442464.0.err", "jdl": "https://aipanda156.cern.ch/condor_logs_2/20-01-23_01/grid.2442464.0.jdl", "pilotErrorCode": 1236, "pilotErrorDiag": "Killed by Harvester due to worker queuing too longCondor HoldReason: submission command failed (exit code = 1) (stdout:) (stderr:cp: cannot create regular file \\u2018/tmp/copia_/tmp/condor_g_scratch.0x2f5e4b00.1589874/bl_1df6ba27ff33\\u2019: No such file or directory-sbatch: error: invalid partition knl_usr_prod-sbatch: error: Batch job submission failed: Unspecified error-Error from sbatch: -) ; Condor RemoveReason: removed by SYSTEM_PERIODIC_REMOVE due to job held time exceeded (3600*4). "}', ':modificationTime': datetime.datetime(2020, 2, 13, 3, 47, 27, 695933), ':lastUpdate': datetime.datetime(2020, 2, 12, 3, 47, 27, 606446), ':lockedBy': None, ':postProcessed': 1, ':nativeStatus': 'removed', ':diagMessage': 'Killed by Harvester due to worker queuing too longCondor HoldReason: submission command failed (exit code = 1) (stdout:) (stderr:cp: cannot create regular file ‘/tmp/copia_/tmp/condor_g_scratch.0x2f5e4b00.1589874/bl_1df6ba27ff33’: No such file or directory-sbatch: error: invalid partition knl_usr_prod-sbatch: error: Batch job submission failed: Unspecified error-Error from sbatch: -) ; Condor RemoveReason: removed by SYSTEM_PERIODIC_REMOVE due to job held time exceeded (3600*4). ', ':checkTime': datetime.datetime(2020, 2, 13, 3, 47, 27, 606480), ':errorCode': 9000, ':errorDiag': 'Condor HoldReason: submission command failed (exit code = 1) (stdout:) (stderr:cp: cannot create regular file ‘/tmp/copia_/tmp/condor_g_scratch.0x2f5e4b00.1589874/bl_1df6ba27ff33’: No such file or directory-sbatch: error: invalid partition knl_usr_prod-sba', ':workerID': 122295655, ':cr_lockedBy': 'monitor-aipanda173.cern.ch_1010853-7fc7d57fa700', ':st1': 'cancelled', ':st2': 'finished', ':st3': 'failed', ':st4': 'missed'}
2020-02-13 03:47:27,696 panda.log.db_proxy: WARNING  _handle_exception <thr=1010853-140496947226688-11> exception of mysql UnicodeEncodeError occurred
2020-02-13 03:47:27,696 panda.log.db_proxy: DEBUG    execute : thr=1010853-140496947226688-11 exception during execute
2020-02-13 03:47:27,697 panda.log.db_proxy: ERROR    update_jobs_workers :  UnicodeEncodeError 'latin-1' codec can't encode character '\u2018' in position 160: ordinal not in range(256) Traceback (most recent call last):
  File "/opt/harvester/lib/python3.6/site-packages/pandaharvester/harvestercore/db_proxy.py", line 2382, in update_jobs_workers
    self.execute(sqlW, varMap)
  File "/opt/harvester/lib/python3.6/site-packages/pandaharvester/harvestercore/db_proxy.py", line 228, in execute
    retVal = self.cur.execute(newSQL, params)
  File "/opt/harvester/lib/python3.6/site-packages/MySQLdb/cursors.py", line 199, in execute
    args = tuple(map(db.literal, args))
  File "/opt/harvester/lib/python3.6/site-packages/MySQLdb/connections.py", line 245, in literal
    s = self.string_literal(o.encode(self.encoding))
UnicodeEncodeError: 'latin-1' codec can't encode character '\u2018' in position 160: ordinal not in range(256)
```
