### PR TITLE
Parse batchID from the end of the stdout 

### DIFF
--- a/pandaharvester/harvestersubmitter/slurm_submitter.py
+++ b/pandaharvester/harvestersubmitter/slurm_submitter.py
@@ -51,7 +51,7 @@ class SlurmSubmitter(PluginBase):
             stdErr_str = stdErr if (isinstance(stdErr, str) or stdErr is None) else stdErr.decode()
             if retCode == 0:
                 # extract batchID
-                workSpec.batchID = re.search('[^0-9]*([0-9]+)[^0-9]*', '{0}'.format(stdOut_str)).group(1)
+                workSpec.batchID = re.search('[^0-9]*([0-9]+)[^0-9]*$', '{0}'.format(stdOut_str)).group(1)
                 tmpLog.debug('batchID={0}'.format(workSpec.batchID))
                 # set log files
                 if self.uploadLog:


### PR DESCRIPTION
On the Frontera HPC, we see stdout from sbatch that looks like the following:
```
-----------------------------------------------------------------
           Welcome to the Frontera Supercomputer
-----------------------------------------------------------------

No reservation for this job
--> Verifying valid submit host (login3)...OK
--> Verifying valid jobname...OK
--> Verifying valid ssh keys...OK
--> Verifying access to desired queue (normal)...OK
--> Checking available allocation (OSG)...OK
Submitted batch job 886697
```

The existing regex search will save the first number it comes across as the batchID. Here's a small code showing this:
```
import re

str="""-----------------------------------------------------------------
           Welcome to the Frontera Supercomputer
-----------------------------------------------------------------

No reservation for this job
--> Verifying valid submit host (login3)...OK
--> Verifying valid jobname...OK
--> Verifying valid ssh keys...OK
--> Verifying access to desired queue (normal)...OK
--> Checking available allocation (OSG)...OK
Submitted batch job 886697
"""

batchID = re.search('[^0-9]*([0-9]+)[^0-9]*', str).group(1)
print(batchID)
```

And when we run it:
```
$ python test.py
3
```

I've made a small patch that just looks for the batchID number at the end of the line instead. It's not a great fix but seems to work for the both a standard sbatch output and the TACC modified output. 