### PR TITLE
isolation transfers for each Panda queue

### DIFF
--- a/pandaharvester/harvesterstager/go_bulk_stager.py
+++ b/pandaharvester/harvesterstager/go_bulk_stager.py
@@ -62,7 +62,7 @@ class GlobusBulkStager(BaseStager):
         tmpLog = self.make_logger(_logger, 'ThreadID={0}'.format(threading.current_thread().ident),
                                   method_name='GlobusBulkStager __init__ ')
         tmpLog.debug('start')
-        self.Yodajob = False 
+        self.EventServicejob = False 
         self.pathConvention = None
         self.id = GlobusBulkStager.next_id
         self.changeFileStatusOnSuccess = True
@@ -126,12 +126,8 @@ class GlobusBulkStager(BaseStager):
         tmpLog = self.make_logger(_logger, 'PandaID={0} ThreadID={1}'.format(jobspec.PandaID,threading.current_thread().ident),
                                   method_name='check_stage_out_status')
         tmpLog.debug('start')
-        # show the dummy transfer id and set to a value with the PandaID if needed.
-        tmpLog.debug('self.dummy_transfer_id = {}'.format(self.dummy_transfer_id))
         # default return
         tmpRetVal = (True, '')
-        # set flag if have db lock
-        have_db_lock = False 
         # check that jobspec.computingSite is defined
         if jobspec.computingSite is None:
             # not found
@@ -139,19 +135,32 @@ class GlobusBulkStager(BaseStager):
             return False, 'jobspec.computingSite is not defined'
         else:
             tmpLog.debug('jobspec.computingSite : {0}'.format(jobspec.computingSite))
+        # show the dummy transfer id and set to a value with the PandaID if needed.
+        tmpLog.debug('self.dummy_transfer_id = {}'.format(self.dummy_transfer_id))
+        if self.dummy_transfer_id == '{0}_{1}'.format(dummy_transfer_id_base,'XXXX') :
+            old_dummy_transfer_id = self.dummy_transfer_id
+            self.dummy_transfer_id = '{0}_{1}'.format(dummy_transfer_id_base,jobspec.computingSite)
+            tmpLog.debug('Change self.dummy_transfer_id  from {0} to {1}'.format(old_dummy_transfer_id,self.dummy_transfer_id))
+        # set flag if have db lock
+        have_db_lock = False 
         # get the queueConfig and corresponding objStoreID_ES
         queueConfigMapper = QueueConfigMapper()
         queueConfig = queueConfigMapper.get_queue(jobspec.computingSite)
         # check queueConfig stager section to see if jobtype is set
         if 'jobtype' in queueConfig.stager:
+            if queueConfig.stager['jobtype'] == "EventService" :
+                self.EventServicejob = True
+                tmpLog.debug('Setting job type to EventService')
+            # guard against old parameter in queue config
             if queueConfig.stager['jobtype'] == "Yoda" :
-                self.Yodajob = True
+                self.EventServicejob = True
+                tmpLog.debug('Setting job type to EventService')
         # set the location of the files in fileSpec.objstoreID
         # see file /cvmfs/atlas.cern.ch/repo/sw/local/etc/agis_ddmendpoints.json 
         self.objstoreID = int(queueConfig.stager['objStoreID_ES'])
-        if self.Yodajob :
+        if self.EventServicejob :
             self.pathConvention = int(queueConfig.stager['pathConvention'])
-            tmpLog.debug('Yoda Job - PandaID = {0} objstoreID = {1} pathConvention ={2}'.format(jobspec.PandaID,self.objstoreID,self.pathConvention))
+            tmpLog.debug('EventService Job - PandaID = {0} objstoreID = {1} pathConvention ={2}'.format(jobspec.PandaID,self.objstoreID,self.pathConvention))
         else:
             self.pathConvention = None
             tmpLog.debug('PandaID = {0} objstoreID = {1}'.format(jobspec.PandaID,self.objstoreID))
@@ -172,10 +181,12 @@ class GlobusBulkStager(BaseStager):
         groups = jobspec.get_groups_of_output_files()
         tmpLog.debug('jobspec.get_groups_of_output_files() = : {0}'.format(groups))
         # lock if the dummy transfer ID is used to avoid submitting duplicated transfer requests
-        if self.dummy_transfer_id in groups:
+        for dummy_transferID in groups:
+            if validate_transferid(dummy_transferID):
+                continue
             # lock for 120 sec
-            tmpLog.debug('attempt to set DB lock for self.id - {0} self.dummy_transfer_id - {1}'.format(self.id,self.dummy_transfer_id))
-            have_db_lock = self.dbInterface.get_object_lock(self.dummy_transfer_id, lock_interval=120)
+            tmpLog.debug('attempt to set DB lock for self.id - {0} dummy_transferID - {1}'.format(self.id,dummy_transferID))
+            have_db_lock = self.dbInterface.get_object_lock(dummy_transferID, lock_interval=120)
             if not have_db_lock:
                 # escape since locked by another thread
                 msgStr = 'escape since locked by another thread'
@@ -189,12 +200,12 @@ class GlobusBulkStager(BaseStager):
             groups = jobspec.get_groups_of_output_files()
             tmpLog.debug('jobspec.get_groups_of_output_files() = : {0}'.format(groups))
             # the dummy transfer ID is still there
-            if self.dummy_transfer_id in groups:
-                groupUpdateTime = groups[self.dummy_transfer_id]['groupUpdateTime']
+            if dummy_transferID in groups:
+                groupUpdateTime = groups[dummy_transferID]['groupUpdateTime']
                 # get files with the dummy transfer ID across jobs
-                fileSpecs = self.dbInterface.get_files_with_group_id(self.dummy_transfer_id)
+                fileSpecs = self.dbInterface.get_files_with_group_id(dummy_transferID)
                 # submit transfer if there are more than 10 files or the group was made before more than 10 min
-                msgStr = 'self.dummy_transfer_id = {0}  number of files = {1}'.format(self.dummy_transfer_id,len(fileSpecs))
+                msgStr = 'dummy_transferID = {0}  number of files = {1}'.format(dummy_transferID,len(fileSpecs))
                 tmpLog.debug(msgStr)
                 if len(fileSpecs) >= 10 or \
                         groupUpdateTime < datetime.datetime.utcnow() - datetime.timedelta(minutes=10):
@@ -222,10 +233,10 @@ class GlobusBulkStager(BaseStager):
                             if not tmpStatdst :
                                 errMsg += ' destination Endpoint not activated '
                             # release process lock
-                            tmpLog.debug('attempt to release DB lock for self.id - {0} self.dummy_transfer_id - {1}'.format(self.id,self.dummy_transfer_id))
-                            self.have_db_lock = self.dbInterface.release_object_lock(self.dummy_transfer_id)
+                            tmpLog.debug('attempt to release DB lock for self.id - {0} dummy_transferID - {1}'.format(self.id,dummy_transferID))
+                            self.have_db_lock = self.dbInterface.release_object_lock(dummy_transferID)
                             if not self.have_db_lock:
-                                errMsg += ' - Could not release DB lock for {}'.format(self.dummy_transfer_id)
+                                errMsg += ' - Could not release DB lock for {}'.format(dummy_transferID)
                             tmpLog.error(errMsg)
                             tmpRetVal = (None,errMsg)
                             return tmpRetVal
@@ -238,10 +249,10 @@ class GlobusBulkStager(BaseStager):
                     except:
                         errStat, errMsg = globus_utils.handle_globus_exception(tmpLog)
                         # release process lock
-                        tmpLog.debug('attempt to release DB lock for self.id - {0} self.dummy_transfer_id - {1}'.format(self.id,self.dummy_transfer_id))
-                        release_db_lock = self.dbInterface.release_object_lock(self.dummy_transfer_id)
+                        tmpLog.debug('attempt to release DB lock for self.id - {0} dummy_transferID - {1}'.format(self.id,dummy_transferID))
+                        release_db_lock = self.dbInterface.release_object_lock(dummy_transferID)
                         if not release_db_lock:
-                            errMsg += ' - Could not release DB lock for {}'.format(self.dummy_transfer_id)
+                            errMsg += ' - Could not release DB lock for {}'.format(dummy_transferID)
                         tmpLog.error(errMsg)
                         tmpRetVal = (errStat, errMsg)
                         return tmpRetVal
@@ -257,8 +268,8 @@ class GlobusBulkStager(BaseStager):
                         scope ='panda'
                         if fileSpec.scope is not None :
                             scope = fileSpec.scope
-                        # for Yoda job set the scope to transient for non log files
-                        if self.Yodajob :
+                        # for EventService job set the scope to transient for non log files
+                        if self.EventServicejob :
                             scope = 'transient'
                         if fileSpec.fileType == "log" :
                             logfile = True
@@ -296,10 +307,10 @@ class GlobusBulkStager(BaseStager):
                         else:
                             errMsg = "source file {} does not exist".format(srcURL)
                             # release process lock
-                            tmpLog.debug('attempt to release DB lock for self.id - {0} self.dummy_transfer_id - {1}'.format(self.id,self.dummy_transfer_id))
-                            release_db_lock = self.dbInterface.release_object_lock(self.dummy_transfer_id)
+                            tmpLog.debug('attempt to release DB lock for self.id - {0} dummy_transferID - {1}'.format(self.id,dummy_transferID))
+                            release_db_lock = self.dbInterface.release_object_lock(dummy_transferID)
                             if not release_db_lock:
-                                errMsg += ' - Could not release DB lock for {}'.format(self.dummy_transfer_id)
+                                errMsg += ' - Could not release DB lock for {}'.format(dummy_transferID)
                             tmpLog.error(errMsg)
                             tmpRetVal = (False,errMsg)
                             return tmpRetVal
@@ -321,45 +332,45 @@ class GlobusBulkStager(BaseStager):
                             tmpLog.debug(msgStr)
                         else:
                             # release process lock
-                            tmpLog.debug('attempt to release DB lock for self.id - {0} self.dummy_transfer_id - {1}'.format(self.id,self.dummy_transfer_id))
-                            release_db_lock = self.dbInterface.release_object_lock(self.dummy_transfer_id)
+                            tmpLog.debug('attempt to release DB lock for self.id - {0} dummy_transferID - {1}'.format(self.id,dummy_transferID))
+                            release_db_lock = self.dbInterface.release_object_lock(dummy_transferID)
                             if not release_db_lock:
-                                errMsg = 'Could not release DB lock for {}'.format(self.dummy_transfer_id)
+                                errMsg = 'Could not release DB lock for {}'.format(dummy_transferID)
                                 tmpLog.error(errMsg)
                             tmpRetVal = (None, transfer_result['message'])
                             return tmpRetVal
                     except Exception as e:
                         errStat,errMsg = globus_utils.handle_globus_exception(tmpLog)
                         # release process lock
-                        tmpLog.debug('attempt to release DB lock for self.id - {0} self.dummy_transfer_id - {1}'.format(self.id,self.dummy_transfer_id))
-                        release_db_lock = self.dbInterface.release_object_lock(self.dummy_transfer_id)
+                        tmpLog.debug('attempt to release DB lock for self.id - {0} dummy_transferID - {1}'.format(self.id,dummy_transferID))
+                        release_db_lock = self.dbInterface.release_object_lock(dummy_transferID)
                         if not release_db_lock:
-                            errMsg += ' - Could not release DB lock for {}'.format(self.dummy_transfer_id)
+                            errMsg += ' - Could not release DB lock for {}'.format(dummy_transferID)
                         tmpLog.error(errMsg)
                         return errStat, errMsg
                 else:
                     msgStr = 'wait until enough files are pooled'
                     tmpLog.debug(msgStr)
                 # release the lock
-                tmpLog.debug('attempt to release DB lock for self.id - {0} self.dummy_transfer_id - {1}'.format(self.id,self.dummy_transfer_id))
-                release_db_lock = self.dbInterface.release_object_lock(self.dummy_transfer_id) 
+                tmpLog.debug('attempt to release DB lock for self.id - {0} dummy_transferID - {1}'.format(self.id,dummy_transferID))
+                release_db_lock = self.dbInterface.release_object_lock(dummy_transferID) 
                 if release_db_lock:
-                    tmpLog.debug('released DB lock for self.id - {0} self.dummy_transfer_id - {1}'.format(self.id,self.dummy_transfer_id))
+                    tmpLog.debug('released DB lock for self.id - {0} dummy_transferID - {1}'.format(self.id,dummy_transferID))
                     have_db_lock = False
                 else:
-                    msgStr += ' - Could not release DB lock for {}'.format(self.dummy_transfer_id)
+                    msgStr += ' - Could not release DB lock for {}'.format(dummy_transferID)
                     tmpLog.error(msgStr)
                 # return None to retry later
                 return None, msgStr
             # release the db lock if needed
             if have_db_lock:
-                tmpLog.debug('attempt to release DB lock for self.id - {0} self.dummy_transfer_id - {1}'.format(self.id,self.dummy_transfer_id))
-                release_db_lock = self.dbInterface.release_object_lock(self.dummy_transfer_id) 
+                tmpLog.debug('attempt to release DB lock for self.id - {0} dummy_transferID - {1}'.format(self.id,dummy_transferID))
+                release_db_lock = self.dbInterface.release_object_lock(dummy_transferID) 
                 if release_db_lock:
-                    tmpLog.debug('released DB lock for self.id - {0} self.dummy_transfer_id - {1}'.format(self.id,self.dummy_transfer_id))
+                    tmpLog.debug('released DB lock for self.id - {0} dummy_transferID - {1}'.format(self.id,dummy_transferID))
                     have_db_lock = False 
                 else:
-                    msgStr += ' - Could not release DB lock for {}'.format(self.dummy_transfer_id)
+                    msgStr += ' - Could not release DB lock for {}'.format(dummy_transferID)
                     tmpLog.error(msgStr)
                     return None, msgStr
         # check transfer with real transfer IDs
@@ -432,6 +443,10 @@ class GlobusBulkStager(BaseStager):
             return False, errStr
         # show the dummy transfer id and set to a value with the PandaID if needed.
         tmpLog.debug('self.dummy_transfer_id = {}'.format(self.dummy_transfer_id))
+        if self.dummy_transfer_id == '{0}_{1}'.format(dummy_transfer_id_base,'XXXX') :
+            old_dummy_transfer_id = self.dummy_transfer_id
+            self.dummy_transfer_id = '{0}_{1}'.format(dummy_transfer_id_base,jobspec.computingSite)
+            tmpLog.debug('Change self.dummy_transfer_id  from {0} to {1}'.format(old_dummy_transfer_id,self.dummy_transfer_id))
         # set the dummy transfer ID which will be replaced with a real ID in check_stage_out_status()
         lfns = []
         for fileSpec in jobspec.get_output_file_specs(skip_done=True):


### PR DESCRIPTION
use the Panda sitename to dummy transfer id to separate the transfers between queues for globus transfers. - requested by Rod