### PR TITLE
queue config mapper: refill if missing 'ANY' types

### DIFF
--- a/pandaharvester/commit_timestamp.py
+++ b/pandaharvester/commit_timestamp.py
@@ -1,1 +1,1 @@
-timestamp = "25-11-2020 13:34:10 on master (by tmaeno)"
+timestamp = "09-12-2020 17:28:36 on flin (by fahui)"

--- a/pandaharvester/commit_timestamp.py
+++ b/pandaharvester/commit_timestamp.py
@@ -1,1 +1,1 @@
-timestamp = "09-12-2020 17:36:08 on flin (by fahui)"
+timestamp = "09-12-2020 17:58:33 on flin (by fahui)"

--- a/pandaharvester/commit_timestamp.py
+++ b/pandaharvester/commit_timestamp.py
@@ -1,1 +1,1 @@
-timestamp = "09-12-2020 17:28:36 on flin (by fahui)"
+timestamp = "09-12-2020 17:36:08 on flin (by fahui)"

--- a/pandaharvester/harvestercore/db_proxy.py
+++ b/pandaharvester/harvestercore/db_proxy.py
@@ -867,6 +867,7 @@ class DBProxy(object):
                     # check if already exist
                     sqlC = "SELECT * FROM {0} ".format(pandaQueueTableName)
                     sqlC += "WHERE queueName=:queueName "
+                    sqlC += " AND resourceType='ANY' AND jobType='ANY' "
                     varMap = dict()
                     varMap[':queueName'] = queueName
                     self.execute(sqlC, varMap)

--- a/pandaharvester/harvestercore/queue_config_mapper.py
+++ b/pandaharvester/harvestercore/queue_config_mapper.py
@@ -270,7 +270,7 @@ class QueueConfigMapper(six.with_metaclass(SingletonWithID, object)):
         return timestamp
 
     # load data
-    def load_data(self):
+    def load_data(self, refill_table=False):
         mainLog = _make_logger(method_name='QueueConfigMapper.load_data')
         with self.lock:
             # check if to update
@@ -608,7 +608,7 @@ class QueueConfigMapper(six.with_metaclass(SingletonWithID, object)):
             self.lastUpdate = datetime.datetime.utcnow()
         # update database
         if self.toUpdateDB:
-            self.dbProxy.fill_panda_queue_table(self.activeQueues.keys(), self)
+            self.dbProxy.fill_panda_queue_table(self.activeQueues.keys(), self, refill_table=refill_table)
             mainLog.debug('updated to DB')
         # done
         mainLog.debug('done')

--- a/pandaharvester/harvesterscripts/harvester_admin.py
+++ b/pandaharvester/harvesterscripts/harvester_admin.py
@@ -198,7 +198,7 @@ def qconf_refresh(arguments):
     qcm = QueueConfigMapper()
     qcm._update_last_reload_time()
     qcm.lastUpdate = None
-    qcm.load_data()
+    qcm.load_data(refill_table=arguments.refill)
 
 def qconf_dump(arguments):
     from pandaharvester.harvesterscripts import queue_config_tool
@@ -327,6 +327,7 @@ def main():
     # qconf refresh command
     qconf_refresh_parser = qconf_subparsers.add_parser('refresh', help='refresh queue configuration immediately')
     qconf_refresh_parser.set_defaults(which='qconf_refresh')
+    qconf_refresh_parser.add_argument('-R', '--refill', dest='refill', action='store_true', help='Refill pq_table before refresh (cleaner)')
     # qconf purge command
     qconf_purge_parser = qconf_subparsers.add_parser('purge', help='Purge the queue thoroughly from harvester DB (Be careful !!)')
     qconf_purge_parser.set_defaults(which='qconf_purge')

--- a/pandaharvester/harvestersubmitter/htcondor_submitter.py
+++ b/pandaharvester/harvestersubmitter/htcondor_submitter.py
@@ -227,14 +227,18 @@ def _get_complicated_pilot_options(pilot_type, pilot_url=None):
     return pilot_opt_dict
 
 
-# get special flag of pilot wrapper to run with python 3 if pilot version is "3"
+# get special flag of pilot wrapper about pilot version , and whehter to run with python 3 if pilot version is "3"
 # FIXME: during pilot testing phase, only prodsourcelabel ptest and rc_test2 should run python3
 # This constraint will be removed when pilot is ready
-def _get_pilot_python_option(pilot_version, prod_source_label):
+def _get_pilot_version_python_option(pilot_version, prod_source_label):
+    version = 'current'
     option = ''
-    if pilot_version in ['3'] and prod_source_label in ['rc_test2', 'ptest']:
-        option = '-3'
-    return option
+    if pilot_version.startswith('3'):
+        if prod_source_label in ['rc_test2', 'ptest']:
+            option = '--pythonversion 3'
+    else:
+        version = pilot_version
+    return version, option
 
 
 # submit a bag of workers
@@ -432,8 +436,8 @@ def make_a_jdl(workspec, template, n_core_per_node, log_dir, panda_queue_name, e
             'ioIntensity': io_intensity,
             'pilotType': pilot_type_opt,
             'pilotUrlOption': pilot_url_str,
-            'pilotVersion': pilot_version,
-            'pilotPythonOption': _get_pilot_python_option(pilot_version, prod_source_label),
+            'pilotVersion': _get_pilot_version_python_option(pilot_version, prod_source_label)[0],
+            'pilotPythonOption': _get_pilot_version_python_option(pilot_version, prod_source_label)[1],
             'submissionHost': workspec.submissionHost,
             'submissionHostShort': workspec.submissionHost.split('.')[0],
         }


### PR DESCRIPTION
> For some reason, there is no row with resourceType='ANY', jobType='ANY' in thepq_table in the central_A DB for RRC-KI-T1
```
MySQL [HARVESTER]> select * from pq_table where jobType='ANY' and resourceType='ANY' and siteName='RRC-KI-T1';
Empty set (0.00 sec)
```
> The absence of this row triggers the KeyError exception in the worker adjuster log below (get_worker_limits returns an empty dict).

The text above is copied from mail thread "Re: No pilots in RRC-KI-T1" , which shows reason for the issue.

Please let me know if my commits do the correct fix. Thanks.
