### PR TITLE
Lancium monitor first commit

### DIFF
--- a/pandaharvester/commit_timestamp.py
+++ b/pandaharvester/commit_timestamp.py
@@ -1,1 +1,1 @@
-timestamp = "23-03-2023 09:51:09 on flin (by mightqxc)"
+timestamp = "31-03-2023 11:42:59 on lancium (by mightqxc)"

--- a/pandaharvester/harvestermisc/lancium_utils.py
+++ b/pandaharvester/harvestermisc/lancium_utils.py
@@ -3,8 +3,21 @@ Lancium python API wrapper functions
 
 """
 
-from pandaharvester.harvesterconfig import harvester_config
 import os
+import time
+import datetime
+import re
+import random
+import threading
+import traceback
+
+from threading import get_ident
+
+from pandaharvester.harvestercore import core_utils
+from pandaharvester.harvesterconfig import harvester_config
+from pandaharvester.harvestercore.core_utils import SingletonWithID
+from pandaharvester.harvestercore.fifos import SpecialFIFOBase
+
 
 try:
     api_key = harvester_config.lancium.api_key
@@ -17,12 +30,330 @@ os.environ['LANCIUM_API_KEY'] = api_key
 from lancium.api.Job import Job
 from lancium.api.Data import Data
 
+
+# logger
+base_logger = core_utils.setup_logger('lancium_utils')
+
+
+LANCIUM_JOB_ATTRS_LIST = [
+    'id',
+    'name',
+    'status',
+    'created_at',
+    'updated_at',
+    'submitted_at',
+    'completed_at',
+]
+
+
+def get_job_name_from_workspec(workspec):
+     job_name = '{0}:{1}'.format(harvester_config.master.harvester_id, workspec.workerID)
+     return job_name
+
+def get_workerid_from_job_name(job_name):
+    tmp_str_list = job_name.split(':')
+    harvester_id = None
+    worker_id = None
+    try:
+        harvester_id = str(tmp_str_list[0])
+        worker_id = int(tmp_str_list[-1])
+    except Exception:
+        pass
+    return (harvester_id, worker_id)
+
+def get_full_batch_id_from_workspec(workspec):
+    full_batch_id = '{0}#{1}'.format(workspec.submissionHost, workspec.batchID)
+    return full_batch_id
+
+def get_host_batch_id_map(workspec_list):
+    """
+    Get a dictionary of submissionHost: list of batchIDs from workspec_list
+    return {submissionHost_1: {batchID_1_1, ...}, submissionHost_2: {...}, ...}
+    """
+    host_batch_id_map = {}
+    for workspec in workspec_list:
+        host = workspec.submissionHost
+        batch_id = workspec.batchID
+        if batch_id is None:
+            continue
+        try:
+            host_batch_id_map[host].append(batch_id)
+        except KeyError:
+            host_batch_id_map[host] = [batch_id]
+    return host_batch_id_map
+
+def timestamp_to_datetime(timestamp_str):
+    return datetime.strptime(timestamp_str, '%Y-%m-%dT%H:%M:%S.%fZ')
+
+
 class LanciumClient(object):
 
-    def __init__(self, queue_name=None):
+    def __init__(self, submission_host, queue_name=None):
+        self.submission_host = submission_host
         self.queue_name = queue_name
+    
+    def get_full_batch_id(self, batch_id):
+        full_batch_id = '{0}#{1}'.format(self.submission_host, batch_id)
+        return full_batch_id
 
 
+class LanciumJobsCacheFifo(SpecialFIFOBase, metaclass=SingletonWithID):
+    """
+    Cache FIFO for Lancium jobs
+    """
+    global_lock_id = -1
+
+    def __init__(self, target, *args, **kwargs):
+        name_suffix = target.split('.')[0]
+        name_suffix = re.sub('-', '_', name_suffix)
+        self.titleName = 'LanciumJobsCache_{0}'.format(name_suffix)
+        SpecialFIFOBase.__init__(self)
+
+    def lock(self, score=None):
+        lock_key = format(int(random.random() * 2**32), 'x')
+        if score is None:
+            score = time.time()
+        retVal = self.putbyid(self.global_lock_id, lock_key, score)
+        if retVal:
+            return lock_key
+        return None
+
+    def unlock(self, key=None, force=False):
+        peeked_tuple = self.peekbyid(id=self.global_lock_id)
+        if peeked_tuple.score is None or peeked_tuple.item is None:
+            return True
+        elif force or self.decode(peeked_tuple.item) == key:
+            self.delete([self.global_lock_id])
+            return True
+        else:
+            return False
+
+
+class LanciumJobQuery(LanciumClient, metaclass=SingletonWithID):
+    # class lock
+    classLock = threading.Lock()
+
+    def __init__(self, cacheEnable=False, cacheRefreshInterval=None, *args, **kwargs):
+        self.submission_host = str(kwargs.get('id'))
+        # Make logger
+        tmpLog = core_utils.make_logger(base_logger, 'submissionHost={0} thrid={1} oid={2}'.format(
+                                            self.submission_host, get_ident(), id(self)), method_name='LanciumJobQuery.__init__')
+        # Initialize
+        with self.classLock:
+            tmpLog.debug('Start')
+            LanciumClient.__init__(self, self.submission_host, *args, **kwargs)
+            # For cache
+            self.cacheEnable = cacheEnable
+            if self.cacheEnable:
+                self.cache = ([], 0)
+                self.cacheRefreshInterval = cacheRefreshInterval
+            tmpLog.debug('Initialize done')
+
+    def query_jobs(self, batchIDs_list=[], all_jobs=False):
+        # Make logger
+        tmpLog = core_utils.make_logger(base_logger, 'submissionHost={0}'.format(self.submission_host), method_name='LanciumJobQuery.query_jobs')
+        # Start query
+        tmpLog.debug('Start query')
+        cache_fifo = None
+        job_attr_all_dict = {}
+        # make id sets
+        batchIDs_set = set(batchIDs_list)
+        # query from cache
+        def cache_query(batch_id_set, timeout=60):
+            # query from lancium job and update cache to fifo
+            def update_cache(lockInterval=90):
+                tmpLog.debug('update_cache')
+                # acquire lock with score timestamp
+                score = time.time() - self.cacheRefreshInterval + lockInterval
+                lock_key = cache_fifo.lock(score=score)
+                if lock_key is not None:
+                    # acquired lock, update
+                    tmpLog.debug('got lock, updating cache')
+                    all_jobs_light_list = Job().all()
+                    jobs_iter = []
+                    for job in all_jobs_light_list:
+                        try:
+                            lancium_job_id = job['id']
+                            one_job_attr = Job().get(lancium_job_id)
+                            one_job_dict = dict()
+                            for attr in LANCIUM_JOB_ATTRS_LIST:
+                                one_job_dict[attr] = one_job_attr.get(attr)
+                            jobs_iter.append(one_job_dict)
+                        except Exception as e:
+                            tmpLog.error('In update_cache all job; got exception {0}: {1} ; {2}'.format(
+                                            e.__class__.__name__, e, repr(job)))
+                    timeNow = time.time()
+                    cache_fifo.put(jobs_iter, timeNow)
+                    self.cache = (jobs_iter, timeNow)
+                    # release lock
+                    retVal = cache_fifo.unlock(key=lock_key)
+                    if retVal:
+                        tmpLog.debug('done update cache and unlock')
+                    else:
+                        tmpLog.warning('cannot unlock... Maybe something wrong')
+                    return jobs_iter
+                else:
+                    tmpLog.debug('cache fifo locked by other thread. Skipped')
+                    return None
+            # remove invalid or outdated caches from fifo
+            def cleanup_cache(timeout=60):
+                tmpLog.debug('cleanup_cache')
+                id_list = list()
+                attempt_timestamp = time.time()
+                n_cleanup = 0
+                while True:
+                    if time.time() > attempt_timestamp + timeout:
+                        tmpLog.debug('time is up when cleanup cache. Skipped')
+                        break
+                    peeked_tuple = cache_fifo.peek(skip_item=True)
+                    if peeked_tuple is None:
+                        tmpLog.debug('empty cache fifo')
+                        break
+                    elif peeked_tuple.score is not None \
+                        and time.time() <= peeked_tuple.score + self.cacheRefreshInterval:
+                        tmpLog.debug('nothing expired')
+                        break
+                    elif peeked_tuple.id is not None:
+                        retVal = cache_fifo.delete([peeked_tuple.id])
+                        if isinstance(retVal, int):
+                            n_cleanup += retVal
+                    else:
+                        # problematic
+                        tmpLog.warning('got nothing when cleanup cache, maybe problematic. Skipped')
+                        break
+                tmpLog.debug('cleaned up {0} objects in cache fifo'.format(n_cleanup))
+            # start
+            jobs_iter = tuple()
+            try:
+                attempt_timestamp = time.time()
+                while True:
+                    if time.time() > attempt_timestamp + timeout:
+                        # skip cache_query if too long
+                        tmpLog.debug('cache_query got timeout ({0} seconds). Skipped '.format(timeout))
+                        break
+                    # get latest cache
+                    peeked_tuple = cache_fifo.peeklast(skip_item=True)
+                    if peeked_tuple is not None and peeked_tuple.score is not None:
+                        # got something
+                        if peeked_tuple.id == cache_fifo.global_lock_id:
+                            if time.time() <= peeked_tuple.score + self.cacheRefreshInterval:
+                                # lock
+                                tmpLog.debug('got fifo locked. Wait and retry...')
+                                time.sleep(random.uniform(1, 5))
+                                continue
+                            else:
+                                # expired lock
+                                tmpLog.debug('got lock expired. Clean up and retry...')
+                                cleanup_cache()
+                                continue
+                        elif time.time() <= peeked_tuple.score + self.cacheRefreshInterval:
+                            # got valid cache
+                            _obj, _last_update = self.cache
+                            if _last_update >= peeked_tuple.score:
+                                # valid local cache
+                                tmpLog.debug('valid local cache')
+                                jobs_iter = _obj
+                            else:
+                                # valid fifo cache
+                                tmpLog.debug('update local cache from fifo')
+                                peeked_tuple_with_item = cache_fifo.peeklast()
+                                if peeked_tuple_with_item is not None \
+                                    and peeked_tuple.id != cache_fifo.global_lock_id \
+                                    and peeked_tuple_with_item.item is not None:
+                                    jobs_iter = cache_fifo.decode(peeked_tuple_with_item.item)
+                                    self.cache = (jobs_iter, peeked_tuple_with_item.score)
+                                else:
+                                    tmpLog.debug('peeked invalid cache fifo object. Wait and retry...')
+                                    time.sleep(random.uniform(1, 5))
+                                    continue
+                        else:
+                            # cache expired
+                            tmpLog.debug('update cache in fifo')
+                            retVal = update_cache()
+                            if retVal is not None:
+                                jobs_iter = retVal
+                            cleanup_cache()
+                        break
+                    else:
+                        # no cache in fifo, check with size again
+                        if cache_fifo.size() == 0:
+                            if time.time() > attempt_timestamp + random.uniform(10, 30):
+                                # have waited for long enough, update cache
+                                tmpLog.debug('waited enough, update cache in fifo')
+                                retVal = update_cache()
+                                if retVal is not None:
+                                    jobs_iter = retVal
+                                break
+                            else:
+                                # still nothing, wait
+                                time.sleep(2)
+                        continue
+            except Exception as _e:
+                tb_str = traceback.format_exc()
+                tmpLog.error('Error querying from cache fifo; {0} ; {1}'.format(_e, tb_str))
+            return jobs_iter
+        def direct_query(batch_id_set, **kwargs):
+            jobs_iter = []
+            batch_ids = batch_id_set
+            if all_jobs:
+                try:
+                    all_jobs_light_list = Job().all()
+                    batch_ids = set()
+                    for job in all_jobs_light_list:
+                        lancium_job_id = job['id']
+                        batch_ids.add(lancium_job_id)
+                except Exception as e:
+                    tmpLog.error('In doing Job().all(); got exception {0}: {1} '.format(
+                                    e.__class__.__name__, e))
+            for batch_id in batch_id_set:
+                try:
+                    lancium_job_id = batch_id
+                    one_job_attr = Job().get(lancium_job_id)
+                    one_job_dict = dict()
+                    for attr in LANCIUM_JOB_ATTRS_LIST:
+                        one_job_dict[attr] = one_job_attr.get(attr)
+                    jobs_iter.append(one_job_dict)
+                except Exception as e:
+                    tmpLog.error('In doing Job().get({0}); got exception {1}: {2} '.format(
+                                    batch_id, e.__class__.__name__, e))
+            return jobs_iter
+        # query method options
+        query_method_list = [direct_query]
+        if self.cacheEnable:
+            cache_fifo = LanciumJobsCacheFifo(target=self.submission_host, idlist='{0},{1}'.format(self.submission_host, get_ident()))
+            query_method_list.insert(0, cache_query)
+        # Go
+        for query_method in query_method_list:
+            # Query
+            jobs_iter = query_method(batch_id_set=batchIDs_set)
+            for job in jobs_iter:
+                try:
+                    job_attr_dict = dict(job)
+                    batch_id = job_attr_dict['id']
+                except Exception as e:
+                    tmpLog.error('in querying; got exception {0}: {1} ; {2}'.format(
+                                    e.__class__.__name__, e, repr(job)))
+                else:
+                    full_batch_id = self.get_full_batch_id(batch_id)
+                    job_attr_all_dict[full_batch_id] = job_attr_dict
+                # Remove batch jobs already gotten from the list
+                if not all_jobs:
+                    batchIDs_set.discard(batch_id)
+            if len(batchIDs_set) == 0 or all_jobs:
+                break
+        # Remaining
+        if not all_jobs and len(batchIDs_set) > 0:
+            # Job unfound, marked as unknown worker in harvester
+            for batch_id in batchIDs_set:
+                full_batch_id = self.get_full_batch_id(batch_id)
+                job_attr_all_dict[full_batch_id] = dict()
+            tmpLog.info( 'Unfound batch jobs of submissionHost={0}: {1}'.format(
+                            self.submission_host, ' '.join(list(batchIDs_set)) ) )
+        # Return
+        return job_attr_all_dict
+
+
+#
 if __name__ == "__main__":
     lancium_client = LanciumClient()
     lancium_client.test()

--- a/pandaharvester/harvestermonitor/lancium_monitor.py
+++ b/pandaharvester/harvestermonitor/lancium_monitor.py
@@ -1,0 +1,250 @@
+import time
+
+from concurrent.futures import ThreadPoolExecutor as Pool
+
+from pandaharvester.harvestercore import core_utils
+from pandaharvester.harvesterconfig import harvester_config
+from pandaharvester.harvestercore.work_spec import WorkSpec
+from pandaharvester.harvestercore.worker_errors import WorkerErrors
+from pandaharvester.harvestercore.plugin_base import PluginBase
+from pandaharvester.harvestercore.pilot_errors import PilotErrors
+from pandaharvester.harvestermisc.lancium_utils import get_full_batch_id_from_workspec, get_workerid_from_job_name, get_host_batch_id_map, timestamp_to_datetime
+from pandaharvester.harvestermisc.lancium_utils import LanciumJobQuery
+
+
+
+# logger
+base_logger = core_utils.setup_logger('lancium_monitor')
+
+# pilot error object
+PILOT_ERRORS = PilotErrors()
+
+
+# Check one worker
+def _check_one_worker(workspec, job_attr_all_dict, cancel_unknown=False, held_timeout=3600):
+    # Make logger for one single worker
+    tmp_log = core_utils.make_logger(base_logger, 'workerID={0}'.format(workspec.workerID), method_name='_check_one_worker')
+    # Initialize newStatus
+    newStatus = workspec.status
+    errStr = ''
+    try:
+        job_attr_dict = job_attr_all_dict[get_full_batch_id_from_workspec(workspec)]
+    except KeyError:
+        got_job_attr = False
+    except Exception as e:
+        got_job_attr = False
+        tmp_log.error('With error {0}'.format(e))
+    else:
+        got_job_attr = True
+    # Parse job ads
+    if got_job_attr:
+        # Check 
+        try:
+            # FIXME
+            new_batch_status = job_attr_dict.get('status')
+        except KeyError:
+            # Propagate native job status as unknown
+            workspec.nativeStatus = 'unknown'
+            if cancel_unknown:
+                newStatus = WorkSpec.ST_cancelled
+                errStr = 'cannot get job status of submissionHost={0} batchID={1}. Regard the worker as canceled'.format(workspec.submissionHost, workspec.batchID)
+                tmp_log.error(errStr)
+            else:
+                newStatus = None
+                errStr = 'cannot get job status of submissionHost={0} batchID={1}. Skipped'.format(workspec.submissionHost, workspec.batchID)
+                tmp_log.warning(errStr)
+        else:
+            # Possible native statuses: "created" "submitted" "queued" "ready" "running" "error" "finished" "delete pending"
+            last_batch_status = workspec.nativeStatus
+            batchStatus = new_batch_status
+            # Set batchStatus if last_batch_status is terminated status
+            if (last_batch_status in ['error', 'finished', 'delete pending'] and new_batch_status not in ['error', 'finished', 'delete pending']) \
+                or (last_batch_status in ['error', 'finished'] and new_batch_status in ['delete pending']):
+                batchStatus = last_batch_status
+                tmp_log.warning('refer to last_batch_status={0} as new status of job submissionHost={1} batchID={2} to avoid reversal in status (new_batch_status={3})'.format(
+                                last_batch_status, workspec.submissionHost, workspec.batchID, new_batch_status))
+            # Propagate native job status
+            workspec.nativeStatus = batchStatus
+            if batchStatus in ['running']:
+                # running
+                newStatus = WorkSpec.ST_running
+            elif batchStatus in ['created', 'submitted', 'queued', 'ready']:
+                # pre-running
+                newStatus = WorkSpec.ST_submitted
+            elif batchStatus in ['error']:
+                # failed
+                errStr += 'job error_string: {0} '.format(job_attr_dict.get('error_string'))
+                newStatus = WorkSpec.ST_failed
+            elif batchStatus in ['delete pending']:
+                # cancelled
+                errStr = 'job error_string: {0} '.format(job_attr_dict.get('error_string'))
+                newStatus = WorkSpec.ST_cancelled
+                # Mark the PanDA job as closed instead of failed
+                workspec.set_pilot_closed()
+                tmp_log.debug('Called workspec set_pilot_closed')
+            elif batchStatus in ['finished']:
+                # finished
+                try:
+                    payloadExitCode_str = str(job_attr_dict['exit_code'])
+                    payloadExitCode = int(payloadExitCode_str)
+                except KeyError:
+                    errStr = 'cannot get exit_code of submissionHost={0} batchID={1}. Regard the worker as failed'.format(workspec.submissionHost, workspec.batchID)
+                    tmp_log.warning(errStr)
+                    newStatus = WorkSpec.ST_failed
+                except ValueError:
+                    errStr = 'got invalid exit_code {0} of submissionHost={1} batchID={2}. Regard the worker as failed'.format(payloadExitCode_str, workspec.submissionHost, workspec.batchID)
+                    tmp_log.warning(errStr)
+                    newStatus = WorkSpec.ST_failed
+                else:
+                    # Propagate exit_code code
+                    workspec.nativeExitCode = payloadExitCode
+                    if payloadExitCode == 0:
+                        # Payload should return 0 after successful run
+                        newStatus = WorkSpec.ST_finished
+                    else:
+                        # Other return codes are considered failed
+                        newStatus = WorkSpec.ST_failed
+                        errStr = 'Payload execution error: returned non-zero {0}'.format(payloadExitCode)
+                        tmp_log.debug(errStr)
+                        # Map return code to Pilot error code
+                        reduced_exit_code = payloadExitCode // 256 if (payloadExitCode % 256 == 0) else payloadExitCode
+                        pilot_error_code, pilot_error_diag = PILOT_ERRORS.convertToPilotErrors(reduced_exit_code)
+                        if pilot_error_code is not None:
+                            workspec.set_pilot_error(pilot_error_code, pilot_error_diag)
+                    tmp_log.info('Payload return code = {0}'.format(payloadExitCode))
+            else:
+                errStr = 'cannot get reasonable job status of submissionHost={0} batchID={1}. Regard the worker as failed by default'.format(
+                            workspec.submissionHost, workspec.batchID)
+                tmp_log.error(errStr)
+                newStatus = WorkSpec.ST_failed
+            tmp_log.info('submissionHost={0} batchID={1} : batchStatus {2} -> workerStatus {3}'.format(
+                            workspec.submissionHost, workspec.batchID, batchStatus, newStatus))
+    else:
+        # Propagate native job status as unknown
+        workspec.nativeStatus = 'unknown'
+        if cancel_unknown:
+            errStr = 'job submissionHost={0} batchID={1} not found. Regard the worker as canceled by default'.format(
+                            workspec.submissionHost, workspec.batchID)
+            tmp_log.error(errStr)
+            newStatus = WorkSpec.ST_cancelled
+            tmp_log.info('submissionHost={0} batchID={1} : batchStatus {2} -> workerStatus {3}'.format(
+                            workspec.submissionHost, workspec.batchID, '3', newStatus))
+        else:
+            errStr = 'job submissionHost={0} batchID={1} not found. Skipped'.format(
+                            workspec.submissionHost, workspec.batchID)
+            tmp_log.warning(errStr)
+            newStatus = None
+    # Set supplemental error message
+    error_code = WorkerErrors.error_codes.get('GENERAL_ERROR') if errStr else WorkerErrors.error_codes.get('SUCCEEDED')
+    workspec.set_supplemental_error(error_code=error_code, error_diag=errStr)
+    # Return
+    return (newStatus, errStr)
+
+
+# monitor for Lancium
+class LanciumMonitor(PluginBase):
+    # constructor
+    def __init__(self, **kwarg):
+        PluginBase.__init__(self, **kwarg)
+        try:
+            self.nProcesses
+        except AttributeError:
+            self.nProcesses = 4
+        try:
+            self.cancelUnknown
+        except AttributeError:
+            self.cancelUnknown = False
+        else:
+            self.cancelUnknown = bool(self.cancelUnknown)
+        try:
+            self.heldTimeout
+        except AttributeError:
+            self.heldTimeout = 3600
+        try:
+            self.cacheEnable = harvester_config.monitor.pluginCacheEnable
+        except AttributeError:
+            self.cacheEnable = False
+        try:
+            self.cacheRefreshInterval = harvester_config.monitor.pluginCacheRefreshInterval
+        except AttributeError:
+            self.cacheRefreshInterval = harvester_config.monitor.checkInterval
+        try:
+            self.submissionHost_list
+        except AttributeError:
+            self.submissionHost_list = []
+
+    # check workers
+    def check_workers(self, workspec_list):
+        # Make logger for batch job query
+        tmp_log = self.make_logger(base_logger, '{0}'.format('batch job query'),
+                                  method_name='check_workers')
+        tmp_log.debug('start')
+        # Loop over submissionHost
+        job_attr_all_dict = {}
+        for submissionHost, batchIDs_list in get_host_batch_id_map(workspec_list).items():
+            # Record batch job query result to this dict, with key = batchID
+            try:
+                job_query = LanciumJobQuery(cacheEnable=self.cacheEnable,
+                                            cacheRefreshInterval=self.cacheRefreshInterval,
+                                            id=submissionHost)
+                host_job_attr_dict = job_query.query_jobs(batchIDs_list=batchIDs_list)
+            except Exception as e:
+                host_job_attr_dict = {}
+                ret_err_str = 'Exception {0}: {1}'.format(e.__class__.__name__, e)
+                tmp_log.error(ret_err_str)
+            job_attr_all_dict.update(host_job_attr_dict)
+        # Check for all workers
+        with Pool(self.nProcesses) as _pool:
+            retIterator = _pool.map(lambda _x: _check_one_worker(
+                                        _x, job_attr_all_dict,
+                                        cancel_unknown=self.cancelUnknown,
+                                        held_timeout=self.heldTimeout),
+                                    workspec_list)
+        retList = list(retIterator)
+        tmp_log.debug('done')
+        return True, retList
+
+    # report updated workers info to monitor to check
+    def report_updated_workers(self, time_window):
+        # Make logger for batch job query
+        tmp_log = self.make_logger(base_logger, method_name='report_updated_workers')
+        tmp_log.debug('start')
+        # Get now timestamp
+        timeNow = time.time()
+        # Set of submission hosts
+        submission_host_set = set()
+        for submissionHost in self.submissionHost_list:
+            submission_host_set.add(submissionHost)
+        # Loop over submissionHost and get all jobs
+        job_attr_all_dict = {}
+        for submissionHost in submission_host_set:
+            try:
+                job_query = LanciumJobQuery(cacheEnable=self.cacheEnable,
+                                            cacheRefreshInterval=self.cacheRefreshInterval,
+                                            id=submissionHost)
+                job_attr_all_dict.update(job_query.query_jobs(all_jobs=True))
+                tmp_log.debug('got information of jobs on {0}'.format(submissionHost))
+            except Exception as e:
+                ret_err_str = 'Exception {0}: {1}'.format(e.__class__.__name__, e)
+                tmp_log.error(ret_err_str)
+        # Choose workers updated within a time window
+        workers_to_check_list = []
+        for full_batch_id, job_attr_dict in job_attr_all_dict.items():
+            # put in worker cache fifo, with lock mechanism
+            job_update_at_str = job_attr_dict.get('updated_at')
+            try:
+                job_update_at = timestamp_to_datetime(job_update_at_str)
+            except Exception as e:
+                ret_err_str = 'Exception {0}: {1}'.format(e.__class__.__name__, e)
+                tmp_log.error(ret_err_str)
+                job_update_at = None
+            if job_update_at is not None and not (job_update_at > timeNow - time_window):
+                continue
+            job_name = job_attr_dict.get('name')
+            harvester_id, worker_id = get_workerid_from_job_name(job_name)
+            if worker_id is None or harvester_id != harvester_config.master.harvester_id:
+                continue
+            workers_to_check_list.append((worker_id, job_update_at))
+        tmp_log.debug('got {0} workers'.format(len(workers_to_check_list)))
+        tmp_log.debug('done')
+        return workers_to_check_list


### PR DESCRIPTION
Hi @fbarreir 

Just let you Know what I have now. Probably I won't really merge at this stage, since the lancium branch is quite outdated.
Basically I implement the monitor with cache as discussed (similar to condor monitor's), but it should run as well without cache configured.
However I haven't thoroughly tested it yet. Maybe after all plugin are finished.

A few other points:

- Maybe you want to update lancium branch with master, before we merge anything
- I put a couple of id-mapping functions in lancium_utils, (e.g. get_job_name_from_workspec), lancium submitter and other plugins had better use them if possible. You can put more common functions there as well
- For now, lets put submissionHost to be None (instead of a real hostname) during submission. I would reserve submissionHost in the future, not for real host of submission, but for different accounts (or different API keys) to access Lancium, if necessary
- Similarly, in the future I will expect per-PQ setup in queue config rather than [lancium] in harvester config
- Not sure if the Lancium API is thread-safe. We will know when running these on Harvester
- Maybe you want to standardize some parameter names between our code (e.g. "work_spec" vs "workspec")
