### PR TITLE
default and warning for ucore + pull

### DIFF
--- a/pandaharvester/commit_timestamp.py
+++ b/pandaharvester/commit_timestamp.py
@@ -1,1 +1,1 @@
-timestamp = "04-05-2023 14:53:58 on flin (by mightqxc)"
+timestamp = "20-06-2023 13:50:46 on flin (by mightqxc)"

--- a/pandaharvester/commit_timestamp.py
+++ b/pandaharvester/commit_timestamp.py
@@ -1,1 +1,1 @@
-timestamp = "20-06-2023 13:50:46 on flin (by mightqxc)"
+timestamp = "20-06-2023 14:31:16 on flin (by mightqxc)"

--- a/pandaharvester/harvesterworkermaker/simple_worker_maker.py
+++ b/pandaharvester/harvesterworkermaker/simple_worker_maker.py
@@ -122,6 +122,10 @@ class SimpleWorkerMaker(BaseWorkerMaker):
                     workSpec.nCore = site_corecount
                     workSpec.minRamCount = site_maxrss
             else:
+                if resource_type not in ['SCORE', 'SCORE_HIMEM', 'MCORE', 'MCORE_HIMEM']:
+                    # some testing PQs have ucore + pure pull, need to default to SCORE
+                    tmpLog.warning('Invalid resource type "{resource_type}" (perhaps due to ucore with pure pull); default to SCORE'.format(resource_type=resource_type))
+                    resource_type = 'SCORE'
                 workSpec.nCore, workSpec.minRamCount = self.rt_mapper.calculate_worker_requirements(resource_type,
                                                                                                     queue_dict)
 

--- a/pandaharvester/harvesterworkermaker/simple_worker_maker.py
+++ b/pandaharvester/harvesterworkermaker/simple_worker_maker.py
@@ -122,7 +122,7 @@ class SimpleWorkerMaker(BaseWorkerMaker):
                     workSpec.nCore = site_corecount
                     workSpec.minRamCount = site_maxrss
             else:
-                if resource_type not in ['SCORE', 'SCORE_HIMEM', 'MCORE', 'MCORE_HIMEM']:
+                if not len(jobspec_list) and resource_type not in ['SCORE', 'SCORE_HIMEM', 'MCORE', 'MCORE_HIMEM']:
                     # some testing PQs have ucore + pure pull, need to default to SCORE
                     tmpLog.warning('Invalid resource type "{resource_type}" (perhaps due to ucore with pure pull); default to SCORE'.format(resource_type=resource_type))
                     resource_type = 'SCORE'


### PR DESCRIPTION
Although ucore + pure pull of a PQ is an invalid configuration (ucore only works with push or pull_ups), it can still exist for testing purpose.
When having ucore + pure pull, the original simple_worker_maker sets the memory requirement = 1 MB (default) due to invalid resource type "ANY", without warning message.
The fix will set the resource type to SCORE, and set memory requirement as the maxrss on CRIC, with warning message about it.
