### PR TITLE
v0.2.34, fix error handling of get_commands

### DIFF
--- a/pandaharvester/commit_timestamp.py
+++ b/pandaharvester/commit_timestamp.py
@@ -1,1 +1,1 @@
-timestamp = "20-06-2023 14:31:16 on flin (by mightqxc)"
+timestamp = "18-07-2023 09:26:51 on flin (by mightqxc)"

--- a/pandaharvester/commit_timestamp.py
+++ b/pandaharvester/commit_timestamp.py
@@ -1,1 +1,1 @@
-timestamp = "18-07-2023 09:26:51 on flin (by mightqxc)"
+timestamp = "18-07-2023 09:28:39 on flin (by mightqxc)"

--- a/pandaharvester/harvestercommunicator/panda_communicator.py
+++ b/pandaharvester/harvestercommunicator/panda_communicator.py
@@ -480,7 +480,7 @@ class PandaCommunicator(BaseCommunicator):
                     tmpLog.debug('Commands {0}'.format(tmp_dict['Commands']))
                     return tmp_dict['Commands']
                 return []
-            except KeyError:
+            except Exception:
                 core_utils.dump_error_message(tmpLog, tmp_res)
         return []
 
@@ -502,7 +502,7 @@ class PandaCommunicator(BaseCommunicator):
                     tmpLog.debug('Finished acknowledging commands')
                     return True
                 return False
-            except KeyError:
+            except Exception:
                 core_utils.dump_error_message(tmpLog, tmp_res)
         return False
 

--- a/pandaharvester/panda_pkg_info.py
+++ b/pandaharvester/panda_pkg_info.py
@@ -1,1 +1,1 @@
-release_version = "0.2.33"
+release_version = "0.2.34"


### PR DESCRIPTION
When command manager posts getCommands to PanDA server and receives empty data (e.g. temporary issue), the following JSONDecodeError will block the entire command manager agent.

```
Exception in thread Thread-2:
Traceback (most recent call last):
  File "/usr/lib64/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/opt/harvester/lib/python3.6/site-packages/pandaharvester/harvesterbody/command_manager.py", line 105, in run
    commands = self.communicator.get_commands(bulk_size)
  File "/opt/harvester/lib/python3.6/site-packages/pandaharvester/harvestercore/communicator_pool.py", line 30, in __call__
    return func(*args, **kwargs)
  File "/opt/harvester/lib/python3.6/site-packages/pandaharvester/harvestercommunicator/panda_communicator.py", line 478, in get_commands
    tmp_dict = tmp_res.json()
  File "/opt/harvester/lib/python3.6/site-packages/requests/models.py", line 897, in json
    return complexjson.loads(self.text, **kwargs)
  File "/usr/lib64/python3.6/json/__init__.py", line 354, in loads
    return _default_decoder.decode(s)
  File "/usr/lib64/python3.6/json/decoder.py", line 339, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib64/python3.6/json/decoder.py", line 357, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

Fixed in this PR.