### PR TITLE
harvester docker updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,9 +72,10 @@ RUN mv /etc/httpd/conf.d/ssl.conf /etc/httpd/conf.d/ssl.conf.back
 COPY docker/httpd.conf /etc/httpd/conf/
 COPY docker/ssl-httpd.conf /etc/httpd/conf.d/
 RUN mkdir -p /opt/harvester/etc/certs
-RUN ln -s /opt/harvester/etc/certs/hostkey.pem /etc/grid-security/hostkey.pem
-RUN ln -s /opt/harvester/etc/certs/hostcert.pem /etc/grid-security/hostcert.pem
-RUN ln -s /opt/harvester/etc/certs/chain.pem /etc/grid-security/chain.pem
+RUN chmod -R 777 /opt/harvester/etc/certs
+RUN ln -fs /opt/harvester/etc/certs/hostkey.pem /etc/grid-security/hostkey.pem
+RUN ln -fs /opt/harvester/etc/certs/hostcert.pem /etc/grid-security/hostcert.pem
+RUN ln -fs /opt/harvester/etc/certs/chain.pem /etc/grid-security/chain.pem
 
 # make lock dir
 ENV PANDA_LOCK_DIR /var/run/panda

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,6 +95,9 @@ RUN chmod +x /opt/harvester/etc/rc.d/init.d/run-harvester-services
 # add condor setup ins sysconfig
 RUN echo source /data/condor/condor/condor.sh >> /opt/harvester/etc/sysconfig/panda_harvester
 
+# add harvester setup
+RUN echo source /data/harvester/setup-harvester >> /opt/harvester/etc/sysconfig/panda_harvester
+
 CMD exec /bin/bash -c "trap : TERM INT; sleep infinity & wait"
 
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,6 +86,14 @@ set -m \n\
 /data/harvester/init-harvester \n\
 /data/harvester/run-harvester-crons & \n\
 source /data/harvester/setup-harvester \n\
+\n\
+# if no host certificate \n\
+if [[ ! -f /opt/harvester/etc/certs/hostkey.pem ]]; then \n\
+    ln -s /etc/pki/tls/certs/localhost.crt   /opt/harvester/etc/certs/hostcert.pem \n\
+    ln -s /etc/pki/tls/private/localhost.key /opt/harvester/etc/certs/hostkey.pem \n\
+    ln -s /etc/pki/tls/certs/ca-bundle.crt   /opt/harvester/etc/certs/chain.pem \n\
+fi \n\
+\n\
 cd /data/condor \n\
 tar -x -f condor.tar.gz${CONDOR_CHANNEL} \n\
 mv condor-*stripped condor \n\

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,8 @@ RUN chmod -R 777 /opt/harvester/etc/certs
 RUN ln -fs /opt/harvester/etc/certs/hostkey.pem /etc/grid-security/hostkey.pem
 RUN ln -fs /opt/harvester/etc/certs/hostcert.pem /etc/grid-security/hostcert.pem
 RUN ln -fs /opt/harvester/etc/certs/chain.pem /etc/grid-security/chain.pem
+RUN chmod 644 /etc/pki/tls/private/localhost.key
+RUN chmod 644 /etc/pki/tls/certs/localhost.crt
 
 # make lock dir
 ENV PANDA_LOCK_DIR /var/run/panda

--- a/docker/httpd.conf
+++ b/docker/httpd.conf
@@ -25,7 +25,6 @@ Alias /condor_logs/ "/var/log/condor_logs/"
 DirectoryIndex disabled
 
 # Errors go to their own log
-LogLevel info
 ErrorLog logs/error_log
 
 # Never change this block
@@ -39,3 +38,5 @@ ErrorLog logs/error_log
   Options +Indexes +FollowSymLinks
   Require all granted
 </Directory>
+
+IncludeOptional conf.d/*.conf

--- a/docker/ssl-httpd.conf
+++ b/docker/ssl-httpd.conf
@@ -1,0 +1,46 @@
+Listen 8443
+
+LoadModule ssl_module /usr/lib64/httpd/modules/mod_ssl.so
+LoadModule socache_shmcb_module modules/mod_socache_shmcb.so
+LoadModule log_config_module    /usr/lib64/httpd/modules/mod_log_config.so
+LoadModule setenvif_module    /usr/lib64/httpd/modules/mod_setenvif.so
+
+<IfModule mod_ssl.c>
+  SSLRandomSeed startup builtin
+  SSLRandomSeed startup file:/dev/urandom 512
+  SSLRandomSeed connect builtin
+  SSLRandomSeed connect file:/dev/urandom 512
+
+  AddType application/x-x509-ca-cert .crt
+  AddType application/x-pkcs7-crl    .crl
+
+  SSLPassPhraseDialog builtin
+  # SSLSessionCache "shmcb:/var/cache/httpd/mod_ssl/scache(512000)"
+  # SSLSessionCacheTimeout 300
+  Mutex default
+  SSLCryptoDevice builtin
+  SSLHonorCipherOrder On
+  SSLUseStapling Off
+  # SSLStaplingCache "shmcb:/var/cache/httpd/mod_ssl/ssl_stapling(32768)"
+  SSLCipherSuite ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
+  SSLProtocol all -SSLv2 -SSLv3 -TLSv1 -TLSv1.1
+  SSLOptions StdEnvVars
+</IfModule>
+
+
+<VirtualHost *:8443>
+    DocumentRoot "/var/www/html"
+
+    ## SSL directives
+    SSLEngine on
+
+    # SSLCertificateFile /etc/pki/tls/certs/localhost.crt
+    # SSLCertificateKeyFile /etc/pki/tls/private/localhost.key
+    # SSLCertificateChainFile /etc/pki/tls/certs/server-chain.crt
+    # SSLCACertificateFile /etc/pki/tls/certs/ca-bundle.crt
+
+    SSLCertificateFile      "/etc/grid-security/hostcert.pem"
+    SSLCertificateKeyFile   "/etc/grid-security/hostkey.pem"
+    SSLCertificateChainFile "/etc/grid-security/chain.pem"
+    KeepAlive off
+</VirtualHost>


### PR DESCRIPTION
(1) enable both http and https for harvester httpd log service: One ingress can only supports prefixes with the same protocol. It cannot support the cases that some prefixes are http and the others are https (tests cannot work). At rubin, we need to export harvester logs to the bigmon ingress with a prefix '/condor_logs'. Currently bigmon is using https. So here I enable harvester to export https too.
(2) add /data/harvester/setup-harvester  to etc/sysconfig/panda_harvester, enables the env setup: The env setup includes K8S_CONFIG (for google k8s cluster in Rubin) and others for different experiments.