### PR TITLE
scope-state-fixed

### DIFF
--- a/pandaharvester/harvesterstager/go_bulk_stager.py
+++ b/pandaharvester/harvesterstager/go_bulk_stager.py
@@ -264,7 +264,7 @@ class GlobusBulkStager(BaseStager):
                             scope = fileSpec.scope
                         # for EventService job set the scope to transient for non log files
                         if self.EventServicejob:
-                            scope = "transient"
+                            pass
                         # only print to log file first 25 files
                         if ifile < 25:
                             msgStr = f"fileSpec.lfn - {fileSpec.lfn} fileSpec.scope - {fileSpec.scope}"


### PR DESCRIPTION
 The change allows the scope for non-log files of EventService jobs to be determined by other parts of the code or configurations without being explicitly set to "transient". 

if self.EventServicejob:
     pass

