### PR TITLE
Harvester to support different nCoreFactor for different resource types in ucore

### DIFF
--- a/pandaharvester/harvesterbody/worker_adjuster.py
+++ b/pandaharvester/harvesterbody/worker_adjuster.py
@@ -69,7 +69,7 @@ class WorkerAdjuster(object):
         return ret_val
 
     # get queue activate worker factor
-    def get_queue_activate_worker_factor(self, site_name=None):
+    def get_queue_activate_worker_factor(self, site_name=None, job_type=None, resource_type=None):
         tmp_log = core_utils.make_logger(_logger, f"site={site_name}", method_name="get_queue_activate_worker_factor")
         ret_val = 1.0
 
@@ -78,14 +78,21 @@ class WorkerAdjuster(object):
             if self.queue_configMapper.has_queue(site_name):
                 queue_config = self.queue_configMapper.get_queue(site_name)
                 # tmp_log.debug("queue_config.submitter:%s" % str(queue_config.submitter))
-                ret_val = 1.0 * float(queue_config.submitter.get("activateWorkerFactor", 1.0))
+                if "activateWorkerFactor" in queue_config.submitter:
+                    ret_val = 1.0 * float(queue_config.submitter.get("activateWorkerFactor", 1.0))
+                elif "nCoreFactor" in queue_config.submitter:
+                    nCoreFactor = queue_config.submitter.get("nCoreFactor")
+                    if type(nCoreFactor) in [dict]:
+                        ret_val = 1.0 / nCoreFactor.get(job_type, {}).get(resource_type, 1)
+                    else:
+                        ret_val = 1.0 / nCoreFactor     # nCoreFactor is number
         except Exception:
             pass
         tmp_log.debug(f"ret_val={ret_val}")
         return ret_val
 
     # get activate worker factor
-    def get_activate_worker_factor(self, site_name=None):
+    def get_activate_worker_factor(self, site_name=None, job_type=None, resource_type=None):
         tmp_log = core_utils.make_logger(_logger, f"site={site_name}", method_name="get_activate_worker_factor")
         ret_val = 1.0
 
@@ -111,7 +118,7 @@ class WorkerAdjuster(object):
             # static factor
             ret_val = self.activate_worker_factor
 
-        queue_factor = self.get_queue_activate_worker_factor(site_name=site_name)
+        queue_factor = self.get_queue_activate_worker_factor(site_name=site_name, job_type=job_type, resource_type=resource_type)
         ret_val = ret_val * queue_factor
 
         tmp_log.debug(f"ret_val={ret_val}")
@@ -269,10 +276,11 @@ class WorkerAdjuster(object):
                                         queue_activated = job_stats[queue_name]["activated"]
                                         tmp_log.debug(f"available activated panda jobs {queue_activated}")
 
-                                        if job_stats[queue_name]["activated"] * self.get_activate_worker_factor(queue_name) > 0:
+                                        activate_worker_factor = self.get_activate_worker_factor(queue_name, job_type, resource_type)
+                                        if job_stats[queue_name]["activated"] * activate_worker_factor > 0:
                                             n_min_pilots = 1
                                         n_activated = max(
-                                            int(job_stats[queue_name]["activated"] * self.get_activate_worker_factor(queue_name)), n_min_pilots
+                                            int(job_stats[queue_name]["activated"] * activate_worker_factor), n_min_pilots
                                         )  # avoid no activity queues
                                     except KeyError:
                                         # zero job in the queue

--- a/pandaharvester/harvestersubmitter/htcondor_submitter.py
+++ b/pandaharvester/harvestersubmitter/htcondor_submitter.py
@@ -394,7 +394,12 @@ class HTCondorSubmitter(PluginBase):
                 self.nProcesses = 1
         # ncore factor
         try:
-            self.nCoreFactor = int(self.nCoreFactor)
+            if type(self.nCoreFactor) in [dict]:
+                # self.nCoreFactor is a dict for ucore
+                # self.nCoreFactor = self.nCoreFactor
+                pass
+            else:
+                self.nCoreFactor = int(self.nCoreFactor)
         except AttributeError:
             self.nCoreFactor = 1
         else:
@@ -778,6 +783,16 @@ class HTCondorSubmitter(PluginBase):
                         tmpLog.debug("Taking default token_dir")
                 return proxy, token_dir
 
+            def get_core_factor(workspec):
+                try:
+                    if type(self.nCoreFactor) in [dict]:
+                        n_core_factor = self.nCoreFactor.get(workspec.resourceType, 1)
+                        return int(n_core_factor)
+                    return int(self.nCoreFactor)
+                except Exception as ex:
+                    tmpLog.warn(f"Failed to get core factor: {ex}")
+                return 1
+
             # initialize
             ce_info_dict = dict()
             batch_log_dict = dict()
@@ -913,7 +928,7 @@ class HTCondorSubmitter(PluginBase):
                         "log_dir": self.logDir,
                         "log_subdir": log_subdir,
                         "n_core_per_node": n_core_per_node,
-                        "n_core_factor": self.nCoreFactor,
+                        "n_core_factor": get_core_factor(workspec),
                         "panda_queue_name": panda_queue_name,
                         "x509_user_proxy": proxy,
                         "ce_info_dict": ce_info_dict,

--- a/pandaharvester/harvestersubmitter/htcondor_submitter.py
+++ b/pandaharvester/harvestersubmitter/htcondor_submitter.py
@@ -648,7 +648,7 @@ class HTCondorSubmitter(PluginBase):
             try:
                 the_prefix = "jdl.plusattr."
                 if k.startswith(the_prefix):
-                    attr_key = k[len(the_prefix) :]
+                    attr_key = k[len(the_prefix):]
                     attr_value = str(v)
                     if not re.fullmatch(r"[a-zA-Z_0-9][a-zA-Z_0-9.\-]*", attr_key):
                         # skip invalid key
@@ -786,7 +786,7 @@ class HTCondorSubmitter(PluginBase):
             def get_core_factor(workspec):
                 try:
                     if type(self.nCoreFactor) in [dict]:
-                        n_core_factor = self.nCoreFactor.get(workspec.resourceType, 1)
+                        n_core_factor = self.nCoreFactor.get(workspec.jobType, {}).get(workspec.resourceType, 1)
                         return int(n_core_factor)
                     return int(self.nCoreFactor)
                 except Exception as ex:

--- a/pandaharvester/harvestersubmitter/slurm_submitter.py
+++ b/pandaharvester/harvestersubmitter/slurm_submitter.py
@@ -40,7 +40,8 @@ class SlurmSubmitter(PluginBase):
             # make logger
             tmpLog = self.make_logger(baseLogger, f"workerID={workSpec.workerID}", method_name="submit_workers")
             # set nCore
-            workSpec.nCore = self.nCore
+            if self.nCore > 0:
+                workSpec.nCore = self.nCore
             # make batch script
             batchFile = self.make_batch_script(workSpec)
             # command

--- a/pandaharvester/harvestersubmitter/slurm_submitter.py
+++ b/pandaharvester/harvestersubmitter/slurm_submitter.py
@@ -1,4 +1,3 @@
-import datetime
 import os
 import re
 import stat
@@ -85,7 +84,7 @@ class SlurmSubmitter(PluginBase):
     def get_core_factor(self, workspec, logger):
         try:
             if type(self.nCoreFactor) in [dict]:
-                n_core_factor = self.nCoreFactor.get(workspec.resourceType, 1)
+                n_core_factor = self.nCoreFactor.get(workspec.jobType, {}).get(workspec.resourceType, 1)
                 return int(n_core_factor)
             return int(self.nCoreFactor)
         except Exception as ex:

--- a/pandaharvester/harvestersubmitter/slurm_submitter_rubin.py
+++ b/pandaharvester/harvestersubmitter/slurm_submitter_rubin.py
@@ -1,4 +1,3 @@
-import datetime
 import os
 import re
 import stat
@@ -105,7 +104,7 @@ class SlurmSubmitter(PluginBase):
     def get_core_factor(self, workspec, logger):
         try:
             if type(self.nCoreFactor) in [dict]:
-                n_core_factor = self.nCoreFactor.get(workspec.resourceType, 1)
+                n_core_factor = self.nCoreFactor.get(workspec.jobType, {}).get(workspec.resourceType, 1)
                 return int(n_core_factor)
             return int(self.nCoreFactor)
         except Exception as ex:

--- a/pandaharvester/harvestersubmitter/slurm_submitter_rubin.py
+++ b/pandaharvester/harvestersubmitter/slurm_submitter_rubin.py
@@ -105,7 +105,8 @@ class SlurmSubmitter(PluginBase):
             # make logger
             tmpLog = self.make_logger(baseLogger, f"workerID={workSpec.workerID}", method_name="submit_workers")
             # set nCore
-            workSpec.nCore = self.nCore
+            if self.nCore > 0:
+                workSpec.nCore = self.nCore
             if num_workSpec % self.nWorkersToCheckPartition == 0:
                 partition = self.get_partition(tmpLog)
                 num_workSpec += 1

--- a/pandaharvester/harvestersubmitter/slurm_submitter_rubin.py
+++ b/pandaharvester/harvestersubmitter/slurm_submitter_rubin.py
@@ -25,7 +25,12 @@ class SlurmSubmitter(PluginBase):
             self.localQueueName = "grid"
         # ncore factor
         try:
-            self.nCoreFactor = int(self.nCoreFactor)
+            if type(self.nCoreFactor) in [dict]:
+                # self.nCoreFactor is a dict for ucore
+                # self.nCoreFactor = self.nCoreFactor
+                pass
+            else:
+                self.nCoreFactor = int(self.nCoreFactor)
         except AttributeError:
             self.nCoreFactor = 1
         else:
@@ -97,6 +102,16 @@ class SlurmSubmitter(PluginBase):
             return selected_partition
         return None
 
+    def get_core_factor(self, workspec, logger):
+        try:
+            if type(self.nCoreFactor) in [dict]:
+                n_core_factor = self.nCoreFactor.get(workspec.resourceType, 1)
+                return int(n_core_factor)
+            return int(self.nCoreFactor)
+        except Exception as ex:
+            logger.warn(f"Failed to get core factor: {ex}")
+        return 1
+
     # submit workers
     def submit_workers(self, workspec_list):
         retList = []
@@ -111,7 +126,7 @@ class SlurmSubmitter(PluginBase):
                 partition = self.get_partition(tmpLog)
                 num_workSpec += 1
             # make batch script
-            batchFile = self.make_batch_script(workSpec, partition)
+            batchFile = self.make_batch_script(workSpec, partition, tmpLog)
             # command
             comStr = f"sbatch -D {workSpec.get_access_point()} {batchFile}"
             # submit
@@ -145,7 +160,7 @@ class SlurmSubmitter(PluginBase):
             retList.append(tmpRetVal)
         return retList
 
-    def make_placeholder_map(self, workspec, partition):
+    def make_placeholder_map(self, workspec, partition, logger):
         timeNow = core_utils.naive_utcnow()
 
         panda_queue_name = self.queueName
@@ -162,16 +177,18 @@ class SlurmSubmitter(PluginBase):
         if not n_core_per_node:
             n_core_per_node = self.nCore
 
+        n_core_factor = self.get_core_factor(workspec, logger)
+
         n_core_total = workspec.nCore if workspec.nCore else n_core_per_node
-        n_core_total_factor = n_core_total * self.nCoreFactor
+        n_core_total_factor = n_core_total * n_core_factor
         request_ram = max(workspec.minRamCount, 1 * n_core_total) if workspec.minRamCount else 1 * n_core_total
         request_disk = workspec.maxDiskCount * 1024 if workspec.maxDiskCount else 1
         request_walltime = workspec.maxWalltime if workspec.maxWalltime else 0
 
         n_node = ceil(n_core_total / n_core_per_node)
-        request_ram_factor = request_ram * self.nCoreFactor
+        request_ram_factor = request_ram * n_core_factor
         request_ram_bytes = request_ram * 2**20
-        request_ram_bytes_factor = request_ram * 2**20 * self.nCoreFactor
+        request_ram_bytes_factor = request_ram * 2**20 * n_core_factor
         request_ram_per_core = ceil(request_ram * n_node / n_core_total)
         request_ram_bytes_per_core = ceil(request_ram_bytes * n_node / n_core_total)
         request_cputime = request_walltime * n_core_total
@@ -181,7 +198,7 @@ class SlurmSubmitter(PluginBase):
         placeholder_map = {
             "nCorePerNode": n_core_per_node,
             "nCoreTotal": n_core_total_factor,
-            "nCoreFactor": self.nCoreFactor,
+            "nCoreFactor": n_core_factor,
             "nNode": n_node,
             "requestRam": request_ram_factor,
             "requestRamBytes": request_ram_bytes_factor,
@@ -212,12 +229,12 @@ class SlurmSubmitter(PluginBase):
         return placeholder_map
 
     # make batch script
-    def make_batch_script(self, workspec, partition):
+    def make_batch_script(self, workspec, partition, logger):
         # template for batch script
         with open(self.templateFile) as f:
             template = f.read()
         tmpFile = tempfile.NamedTemporaryFile(delete=False, suffix="_submit.sh", dir=workspec.get_access_point())
-        placeholder = self.make_placeholder_map(workspec, partition)
+        placeholder = self.make_placeholder_map(workspec, partition, logger)
         tmpFile.write(str(template.format_map(core_utils.SafeDict(placeholder))).encode("latin_1"))
         tmpFile.close()
 


### PR DESCRIPTION
Harvester to support different nCoreFactor for different resource types in ucore
fix harvester to allow worker to use job's corecount in slurm submitter