### PR TITLE
Fix scope issue for Raythena output files 

### DIFF
--- a/pandaharvester/harvesterstager/go_bulk_stager.py
+++ b/pandaharvester/harvesterstager/go_bulk_stager.py
@@ -263,7 +263,7 @@ class GlobusBulkStager(BaseStager):
                             scope = fileSpec.scope
                         # for EventService job set the scope to transient for non log files
                         if self.EventServicejob:
-                            pass
+                            scope = scope
                         # only print to log file first 25 files
                         if ifile < 25:
                             msgStr = f"fileSpec.lfn - {fileSpec.lfn} fileSpec.scope - {fileSpec.scope}"


### PR DESCRIPTION
 "Removed the incorrect setting of the 'transient' scope for Raythena output files."

 if self.EventServicejob: 
     scope = "transient" 

to 

 if self.EventServicejob: 
     scope = scope

at line 267