### PR TITLE
update apfmon message

### DIFF
--- a/pandaharvester/harvestermisc/apfmon.py
+++ b/pandaharvester/harvestermisc/apfmon.py
@@ -295,6 +295,10 @@ class Apfmon(object):
                     apfmon_worker = {
                         "cid": batch_id,
                         "factory": factory,
+                        "harvesterid": self.harvester_id,
+                        "workerid": worker_id,
+                        "computingsite": computingsite,
+                        "computingelement": ce,
                         "label": f"{computingsite}-{ce}",
                         "jdlurl": jdl_url,
                         "stdouturl": stdout_url,


### PR DESCRIPTION
Add ID fields to apfmon message, also split computingsite and ce since the joined field is ambiguous since hyphens can appear in either field.