### PR TITLE
fix n_node

### DIFF
--- a/pandaharvester/harvestersubmitter/htcondor_submitter.py
+++ b/pandaharvester/harvestersubmitter/htcondor_submitter.py
@@ -219,7 +219,10 @@ def make_a_jdl(
             tmpLog.debug(f"job attributes override by CRIC special_par: {attr}={str(_match.group(1))}")
     # derived job attributes
     n_core_total_factor = n_core_total * n_core_factor
-    n_node = ceil(n_core_total / n_core_per_node)
+    if not n_core_per_node or n_core_per_node < 1:
+        n_node = 1
+    else:
+        n_node = ceil(n_core_total / n_core_per_node)
     request_ram_factor = request_ram * n_core_factor
     request_ram_bytes = request_ram * 2**20
     request_ram_bytes_factor = request_ram * 2**20 * n_core_factor
@@ -667,7 +670,7 @@ class HTCondorSubmitter(PluginBase):
 
         # get override requirements from queue configured
         try:
-            n_core_per_node = self.nCorePerNode if self.nCorePerNode else n_core_per_node_from_queue
+            n_core_per_node = self.nCorePerNode if self.nCorePerNode is not None else n_core_per_node_from_queue
         except AttributeError:
             n_core_per_node = n_core_per_node_from_queue
 

--- a/pandaharvester/harvestersubmitter/slurm_submitter.py
+++ b/pandaharvester/harvestersubmitter/slurm_submitter.py
@@ -118,7 +118,7 @@ class SlurmSubmitter(PluginBase):
         request_walltime = workspec.maxWalltime if workspec.maxWalltime else 0
 
         if not n_core_per_node or n_core_per_node < 1:
-            n_node =1
+            n_node = 1
         else:
             n_node = ceil(n_core_total / n_core_per_node)
         request_ram_factor = request_ram * n_core_factor

--- a/pandaharvester/harvestersubmitter/slurm_submitter.py
+++ b/pandaharvester/harvestersubmitter/slurm_submitter.py
@@ -103,7 +103,7 @@ class SlurmSubmitter(PluginBase):
 
         # get override requirements from queue configured
         try:
-            n_core_per_node = self.nCorePerNode if self.nCorePerNode else n_core_per_node_from_queue
+            n_core_per_node = self.nCorePerNode if self.nCorePerNode is not None else n_core_per_node_from_queue
         except AttributeError:
             n_core_per_node = n_core_per_node_from_queue
         if not n_core_per_node:
@@ -117,7 +117,10 @@ class SlurmSubmitter(PluginBase):
         request_disk = workspec.maxDiskCount * 1024 if workspec.maxDiskCount else 1
         request_walltime = workspec.maxWalltime if workspec.maxWalltime else 0
 
-        n_node = ceil(n_core_total / n_core_per_node)
+        if not n_core_per_node or n_core_per_node < 1:
+            n_node =1
+        else:
+            n_node = ceil(n_core_total / n_core_per_node)
         request_ram_factor = request_ram * n_core_factor
         request_ram_bytes = request_ram * 2**20
         request_ram_bytes_factor = request_ram * 2**20 * n_core_factor

--- a/pandaharvester/harvestersubmitter/slurm_submitter_rubin.py
+++ b/pandaharvester/harvestersubmitter/slurm_submitter_rubin.py
@@ -165,7 +165,7 @@ class SlurmSubmitter(PluginBase):
             # make batch script
             batchFile = self.make_batch_script(workSpec, partition, this_panda_queue_dict, tmpLog)
             # command
-            comStr = f"sbatch -D {workSpec.get_access_point()} {batchFile}"
+            comStr = f"sbatch --exclusive=user -D {workSpec.get_access_point()} {batchFile}"
             # submit
             tmpLog.debug(f"submit with {batchFile}")
             p = subprocess.Popen(comStr.split(), shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/pandaharvester/harvestersubmitter/slurm_submitter_rubin.py
+++ b/pandaharvester/harvestersubmitter/slurm_submitter_rubin.py
@@ -208,7 +208,7 @@ class SlurmSubmitter(PluginBase):
 
         # get override requirements from queue configured
         try:
-            n_core_per_node = self.nCorePerNode if self.nCorePerNode else n_core_per_node_from_queue
+            n_core_per_node = self.nCorePerNode if self.nCorePerNode is not None else n_core_per_node_from_queue
         except AttributeError:
             n_core_per_node = n_core_per_node_from_queue
         if n_core_per_node < 1 and self.nCore > 0:
@@ -247,7 +247,10 @@ class SlurmSubmitter(PluginBase):
                     n_core_total = int(_match.group(1))
                 logger.debug(f"job attributes override by CRIC special_par: {attr}={str(_match.group(1))}")
 
-        n_node = ceil(n_core_total / n_core_per_node)
+        if not n_core_per_node or n_core_per_node < 1:
+            n_node = 1
+        else:
+            n_node = ceil(n_core_total / n_core_per_node)
         n_core_total_factor = n_core_total * n_core_factor
         request_ram_factor = request_ram * n_core_factor
         request_ram_bytes = request_ram * 2**20


### PR DESCRIPTION
for push queues that different tasks may request different number of cores, we may don't want to define n_core_per_node (set it to 0) and we want n_node is always be 1. In this way, the `request_ram_per_core = ceil(request_ram * n_node / n_core_total)` is what we want. In the original codes without this patch, n_node will be equal to n_core_total, as a result, request_ram_per_core is request_ram for multiple cores.