### PR TITLE
Fix: Do not override Raythena output file scope with 'transient'

### DIFF
--- a/pandaharvester/harvesterstager/go_bulk_stager.py
+++ b/pandaharvester/harvesterstager/go_bulk_stager.py
@@ -261,9 +261,9 @@ class GlobusBulkStager(BaseStager):
                         scope = "panda"
                         if fileSpec.scope is not None:
                             scope = fileSpec.scope
-                        # for EventService job set the scope to transient for non log files
-                        if self.EventServicejob:
-                            scope = scope
+                        #The scope of the Raythena output files should not be "transient" so this is removed
+                        # if self.EventServicejob:
+                        #     scope = scope
                         # only print to log file first 25 files
                         if ifile < 25:
                             msgStr = f"fileSpec.lfn - {fileSpec.lfn} fileSpec.scope - {fileSpec.scope}"


### PR DESCRIPTION
### Problem
Currently, Raythena output files are assigned the "transient" scope
if the job is marked as an EventService job. This causes issues
because Raythena outputs should keep their proper dataset scope
(either from `fileSpec.scope` or the default "panda").

### Solution
Removed the code that overrides the scope to "transient".
Now output files retain their intended scope.

### Impact
- Raythena outputs will no longer be incorrectly marked as transient.
- Default behavior: use `fileSpec.scope` if available, otherwise "panda".
- No effect on non-EventService jobs.


