### PR TITLE
Raythena scope set incorrectly for output files #201

### DIFF
--- a/pandaharvester/harvesterstager/go_bulk_stager.py
+++ b/pandaharvester/harvesterstager/go_bulk_stager.py
@@ -261,9 +261,7 @@ class GlobusBulkStager(BaseStager):
                         scope = "panda"
                         if fileSpec.scope is not None:
                             scope = fileSpec.scope
-                        #The scope of the Raythena output files should not be "transient" so this is removed
-                        # if self.EventServicejob:
-                        #     scope = scope
+                        #The scope of the Raythena output files should not be "transient" so this is remove.
                         # only print to log file first 25 files
                         if ifile < 25:
                             msgStr = f"fileSpec.lfn - {fileSpec.lfn} fileSpec.scope - {fileSpec.scope}"


### PR DESCRIPTION
Removed the code for the incorrect file  # for the EventService job, set the scope to transient for non-log files  code being removed