### PR TITLE
fix: prevent global lock leak in db_proxy commit() and pool guard

### DIFF
--- a/pandaharvester/harvestercore/db_proxy.py
+++ b/pandaharvester/harvestercore/db_proxy.py
@@ -334,11 +334,12 @@ class DBProxy(object):
             if harvester_config.db.verbose:
                 self.verbLog.debug(f"thr={self.thrName} exception during commit")
             raise
-        if self.usingAppLock and self.lockDB:
-            if harvester_config.db.verbose:
-                self.verbLog.debug(f"thr={self.thrName} release with commit")
-            conLock.release()
-            self.lockDB = False
+        finally:
+            if self.usingAppLock and self.lockDB:
+                if harvester_config.db.verbose:
+                    self.verbLog.debug(f"thr={self.thrName} release with commit")
+                conLock.release()
+                self.lockDB = False
 
     # rollback
     def rollback(self):

--- a/pandaharvester/harvestercore/db_proxy_pool.py
+++ b/pandaharvester/harvestercore/db_proxy_pool.py
@@ -22,6 +22,7 @@ class DBProxyMethod(object):
     def __call__(self, *args, **kwargs):
         tmpLog = core_utils.make_logger(_logger, f"method={self.methodName}", method_name="call")
         sw = core_utils.get_stopwatch()
+        con = None
         try:
             # get connection
             con = self.pool.get()
@@ -32,8 +33,9 @@ class DBProxyMethod(object):
             # exec
             return func(*args, **kwargs)
         finally:
-            tmpLog.debug("release lock" + sw.get_elapsed_time())
-            self.pool.put(con)
+            if con is not None:
+                tmpLog.debug("release lock" + sw.get_elapsed_time())
+                self.pool.put(con)
 
 
 # connection class


### PR DESCRIPTION

## Description

This PR fixes a deadlock issue in PandaHarvester caused by a global DB lock not being released when `commit()` fails.

If a database error occurred during `commit()`, the application-level lock remained held, which could block all Harvester threads and freeze the system until a restart.

---

## Fix

The lock release logic in `commit()` is moved into a `finally` block so it is always executed, even when an exception is raised. This follows the same safe pattern already used in `rollback()`.

A small defensive fix is also added in the DB connection pool to ensure a connection is only returned to the pool if it was successfully acquired.

---

## Files Changed

* `pandaharvester/harvestercore/db_proxy.py`
* `pandaharvester/harvestercore/db_proxy_pool.py`

---

## Impact

* Prevents system-wide deadlocks on database failures
* Allows the system to recover gracefully without restarts
* No change to normal success paths

