### PR TITLE
Install s-nail so the mail command actually works

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN yum-config-manager --enable crb
 
 RUN dnf install -y --allowerasing gcc make less git psmisc curl voms-clients-cpp wget httpd logrotate procps mod_ssl \
     openssl-devel readline-devel bzip2-devel libffi-devel zlib-devel passwd voms-clients-java which mysql-devel mariadb \
-    sudo vim htop
+    sudo vim htop s-nail
 
 # install python
 RUN mkdir /tmp/python && cd /tmp/python && \


### PR DESCRIPTION
A few of the sandbox scripts already used by panda-k8s (doma.vomsproxy-renew, lsst_prod.vomsproxy-renew, lsst.vomsproxy-renew) pipe warnings through `mail -s ...` when a grid proxy is about to expire, but the mail command isn't installed in this image at all - confirmed directly against a running pod. Those calls have presumably been silently failing this whole time.

On AlmaLinux 9/RHEL 9, the old mailx package was replaced by s-nail, which is what actually provides /usr/bin/mail (confirmed via `dnf provides '*/bin/mail'` against a live pod, not just assumed from general RHEL knowledge). Adds it to the existing dnf install line.

We ran into this while adding a new disk-usage alert to health_monitor.py in panda-k8s that also wants to use mail - this fix is what unblocks that.